### PR TITLE
fix(server): now api/spotify returns errors

### DIFF
--- a/server/api/spotify/routes.py
+++ b/server/api/spotify/routes.py
@@ -18,11 +18,11 @@ def auth():
     if response.get("error"):
         res = jsonify(response["error"])
         res.status_code = response["status_code"]
-
-    res = {
-        "access_token": response["access_token"],
-        "refresh_token": response["refresh_token"],
-    }
+    else:
+        res = {
+            "access_token": response["access_token"],
+            "refresh_token": response["refresh_token"],
+        }
 
     return jsonify(res)
 
@@ -36,9 +36,9 @@ def refresh():
     if response.get("error"):
         res = jsonify(response["error"])
         res.status_code = response["status_code"]
-
-    res = {
-        "access_token": response["access_token"],
-    }
+    else:
+        res = {
+            "access_token": response["access_token"],
+        }
 
     return jsonify(res)


### PR DESCRIPTION
Fixed a problem with the code that prevented the api/spotify endpoint from returning errors from Spotify

## Type of change

- [x] Bug fix 🐛
- [ ] Refactor 🔨
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] This change requires a documentation update 📝

## Focus

Please indicate which section the change is directed to

- [ ] Frontend 📱
- [x] Backend 🗄️

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
