### PR TITLE
fix(server): now api/spotify returns errors

### DIFF
--- a/server/api/__init__.py
+++ b/server/api/__init__.py
@@ -10,7 +10,6 @@ from api.spotify import route as spotify
 app = Flask(__name__)
 CORS(app)
 
-app.secret_key = environ.get("SECRET_KEY")
 app.config["MAIL_SERVER"] = environ.get("MAIL_SERVER")
 app.config["MAIL_PORT"] = environ.get("MAIL_PORT")
 app.config["MAIL_USE_TLS"] = False

--- a/server/api/spotify/routes.py
+++ b/server/api/spotify/routes.py
@@ -16,15 +16,14 @@ def auth():
 
     response = spotify.access_token(code)
     if response.get("error"):
-        res = jsonify(response["error"])
-        res.status_code = response["status_code"]
+        return jsonify(response["error"]), response["status_code"]
 
-    res = {
-        "access_token": response["access_token"],
-        "refresh_token": response["refresh_token"],
-    }
-
-    return jsonify(res)
+    return jsonify(
+        {
+            "access_token": response["access_token"],
+            "refresh_token": response["refresh_token"],
+        }
+    )
 
 
 @route.route("/auth/refresh")
@@ -34,11 +33,10 @@ def refresh():
     response = spotify.refresh(refresh_token)
 
     if response.get("error"):
-        res = jsonify(response["error"])
-        res.status_code = response["status_code"]
+        return jsonify(response["error"]), response["status_code"]
 
-    res = {
-        "access_token": response["access_token"],
-    }
-
-    return jsonify(res)
+    return jsonify(
+        {
+            "access_token": response["access_token"],
+        }
+    )


### PR DESCRIPTION
Fixed a problem with the code that prevented the api/spotify endpoint from returning errors from Spotify

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

- [x] Bug fix 🐛
- [x] Refactor 🔨
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] This change requires a documentation update 📝

## Focus

Please indicate which section the change is directed to

- [ ] Frontend 📱
- [x] Backend 🗄️

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
